### PR TITLE
Add WetLab plot chart settings

### DIFF
--- a/src/main/java/eu/crg/qsample/charts/controller/ChartController.java
+++ b/src/main/java/eu/crg/qsample/charts/controller/ChartController.java
@@ -6,18 +6,26 @@ import eu.crg.qsample.charts.dto.ChartConfigDTO;
 import eu.crg.qsample.charts.dto.ChartDataPointDTO;
 import eu.crg.qsample.charts.dto.ChartDefinitionDTO;
 import eu.crg.qsample.charts.dto.ChartSeriesDataPointDTO;
+import eu.crg.qsample.charts.dto.WetlabPlotConfigDTO;
+import eu.crg.qsample.charts.dto.WetlabPlotConfigSaveDTO;
 import eu.crg.qsample.charts.entity.ApplicationChartConfig;
 import eu.crg.qsample.charts.entity.ChartDefinition;
 import eu.crg.qsample.charts.entity.ChartParameter;
+import eu.crg.qsample.charts.entity.WetlabPlotConfig;
 import eu.crg.qsample.charts.repository.ApplicationChartConfigRepository;
 import eu.crg.qsample.charts.repository.ChartDataRepository;
 import eu.crg.qsample.charts.repository.ChartDefinitionRepository;
 import eu.crg.qsample.charts.repository.ChartPageAssignmentRepository;
+import eu.crg.qsample.charts.repository.WetlabPlotConfigRepository;
+import eu.crg.qsample.plot.Plot;
+import eu.crg.qsample.plot.PlotRepository;
 import eu.crg.qsample.qgenerator.application.Application;
 import eu.crg.qsample.qgenerator.application.ApplicationConstraint;
 import eu.crg.qsample.qgenerator.application.ApplicationRepository;
 import eu.crg.qsample.request.local.RequestLocal;
 import eu.crg.qsample.request.local.RequestRepository;
+import eu.crg.qsample.wetlab.WetLab;
+import eu.crg.qsample.wetlab.WetLabRepository;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;
@@ -35,6 +43,9 @@ public class ChartController {
     private final RequestRepository requestRepository;
     private final ApplicationRepository applicationRepository;
     private final ApplicationChartConfigRepository applicationChartConfigRepository;
+    private final WetLabRepository wetLabRepository;
+    private final PlotRepository plotRepository;
+    private final WetlabPlotConfigRepository wetlabPlotConfigRepository;
 
     public ChartController(
             ChartDefinitionRepository chartDefinitionRepository,
@@ -42,7 +53,10 @@ public class ChartController {
             ChartDataRepository chartDataRepository,
             RequestRepository requestRepository,
             ApplicationRepository applicationRepository,
-            ApplicationChartConfigRepository applicationChartConfigRepository
+            ApplicationChartConfigRepository applicationChartConfigRepository,
+            WetLabRepository wetLabRepository,
+            PlotRepository plotRepository,
+            WetlabPlotConfigRepository wetlabPlotConfigRepository
     ) {
         this.chartDefinitionRepository = chartDefinitionRepository;
         this.chartPageAssignmentRepository = chartPageAssignmentRepository;
@@ -50,6 +64,9 @@ public class ChartController {
         this.requestRepository = requestRepository;
         this.applicationRepository = applicationRepository;
         this.applicationChartConfigRepository = applicationChartConfigRepository;
+        this.wetLabRepository = wetLabRepository;
+        this.plotRepository = plotRepository;
+        this.wetlabPlotConfigRepository = wetlabPlotConfigRepository;
     }
 
     @GetMapping
@@ -215,6 +232,112 @@ public class ChartController {
                 .stream()
                 .sorted(java.util.Comparator.comparing(ApplicationChartConfig::getOrderIndex))
                 .map(this::toApplicationChartConfigDTO)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/wetlab-config/{wetlabId}")
+    public List<WetlabPlotConfigDTO> getWetlabPlotConfig(
+            @PathVariable Long wetlabId) {
+
+        return wetlabPlotConfigRepository
+                .findByWetlabIdOrderByOrderIndexAsc(wetlabId)
+                .stream()
+                .map(this::toWetlabPlotConfigDTO)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/wetlab-config/{wetlabId}/initialize")
+    public List<WetlabPlotConfigDTO> initializeWetlabPlotConfig(
+            @PathVariable Long wetlabId) {
+
+        WetLab wetlab = wetLabRepository
+                .findById(wetlabId)
+                .orElseThrow();
+
+        List<WetlabPlotConfig> existingConfigs =
+                wetlabPlotConfigRepository
+                        .findByWetlabIdOrderByOrderIndexAsc(wetlabId);
+
+        if (!existingConfigs.isEmpty()) {
+            return existingConfigs
+                    .stream()
+                    .map(this::toWetlabPlotConfigDTO)
+                    .collect(Collectors.toList());
+        }
+
+        List<WetlabPlotConfig> newConfigs =
+                new java.util.ArrayList<>();
+
+        List<Plot> plots = wetlab.getPlot();
+
+        if (plots != null) {
+            for (int i = 0; i < plots.size(); i++) {
+                WetlabPlotConfig config = new WetlabPlotConfig();
+                config.setWetlab(wetlab);
+                config.setPlot(plots.get(i));
+                config.setEnabled(true);
+                config.setOrderIndex(i + 1);
+
+                newConfigs.add(config);
+            }
+        }
+
+        return wetlabPlotConfigRepository
+                .saveAll(newConfigs)
+                .stream()
+                .map(this::toWetlabPlotConfigDTO)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/wetlab-config/{wetlabId}")
+    public List<WetlabPlotConfigDTO> saveWetlabPlotConfig(
+            @PathVariable Long wetlabId,
+            @RequestBody List<WetlabPlotConfigSaveDTO> configDTOs) {
+
+        WetLab wetlab = wetLabRepository
+                .findById(wetlabId)
+                .orElseThrow();
+
+        List<WetlabPlotConfig> existingConfigs =
+                wetlabPlotConfigRepository
+                        .findByWetlabIdOrderByOrderIndexAsc(wetlabId);
+
+        Map<Long, WetlabPlotConfig> existingByPlotId =
+                existingConfigs
+                        .stream()
+                        .collect(Collectors.toMap(
+                                config -> config.getPlot().getId(),
+                                config -> config
+                        ));
+
+        List<WetlabPlotConfig> configsToSave =
+                new java.util.ArrayList<>();
+
+        for (WetlabPlotConfigSaveDTO dto : configDTOs) {
+            Plot plot = plotRepository
+                    .findById(dto.getPlotId())
+                    .orElseThrow();
+
+            WetlabPlotConfig config =
+                    existingByPlotId.get(dto.getPlotId());
+
+            if (config == null) {
+                config = new WetlabPlotConfig();
+                config.setWetlab(wetlab);
+                config.setPlot(plot);
+            }
+
+            config.setEnabled(Boolean.TRUE.equals(dto.getEnabled()));
+            config.setOrderIndex(dto.getOrderIndex());
+
+            configsToSave.add(config);
+        }
+
+        return wetlabPlotConfigRepository
+                .saveAll(configsToSave)
+                .stream()
+                .sorted(java.util.Comparator.comparing(WetlabPlotConfig::getOrderIndex))
+                .map(this::toWetlabPlotConfigDTO)
                 .collect(Collectors.toList());
     }
 
@@ -451,6 +574,21 @@ public class ChartController {
                 chart.getTitle(),
                 chart.getChartType(),
                 chart.getDataSourceKey(),
+                config.getEnabled(),
+                config.getOrderIndex()
+        );
+    }
+
+    private WetlabPlotConfigDTO toWetlabPlotConfigDTO(
+            WetlabPlotConfig config) {
+
+        Plot plot = config.getPlot();
+
+        return new WetlabPlotConfigDTO(
+                config.getId(),
+                config.getWetlab().getId(),
+                plot.getId(),
+                plot.getName(),
                 config.getEnabled(),
                 config.getOrderIndex()
         );

--- a/src/main/java/eu/crg/qsample/charts/dto/WetlabPlotConfigDTO.java
+++ b/src/main/java/eu/crg/qsample/charts/dto/WetlabPlotConfigDTO.java
@@ -1,0 +1,51 @@
+package eu.crg.qsample.charts.dto;
+
+public class WetlabPlotConfigDTO {
+
+    private Long id;
+    private Long wetlabId;
+    private Long plotId;
+    private String plotName;
+    private Boolean enabled;
+    private Integer orderIndex;
+
+    public WetlabPlotConfigDTO(
+            Long id,
+            Long wetlabId,
+            Long plotId,
+            String plotName,
+            Boolean enabled,
+            Integer orderIndex
+    ) {
+        this.id = id;
+        this.wetlabId = wetlabId;
+        this.plotId = plotId;
+        this.plotName = plotName;
+        this.enabled = enabled;
+        this.orderIndex = orderIndex;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getWetlabId() {
+        return wetlabId;
+    }
+
+    public Long getPlotId() {
+        return plotId;
+    }
+
+    public String getPlotName() {
+        return plotName;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public Integer getOrderIndex() {
+        return orderIndex;
+    }
+}

--- a/src/main/java/eu/crg/qsample/charts/dto/WetlabPlotConfigSaveDTO.java
+++ b/src/main/java/eu/crg/qsample/charts/dto/WetlabPlotConfigSaveDTO.java
@@ -1,0 +1,32 @@
+package eu.crg.qsample.charts.dto;
+
+public class WetlabPlotConfigSaveDTO {
+
+    private Long plotId;
+    private Boolean enabled;
+    private Integer orderIndex;
+
+    public Long getPlotId() {
+        return plotId;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public Integer getOrderIndex() {
+        return orderIndex;
+    }
+
+    public void setPlotId(Long plotId) {
+        this.plotId = plotId;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setOrderIndex(Integer orderIndex) {
+        this.orderIndex = orderIndex;
+    }
+}

--- a/src/main/java/eu/crg/qsample/charts/entity/WetlabPlotConfig.java
+++ b/src/main/java/eu/crg/qsample/charts/entity/WetlabPlotConfig.java
@@ -1,0 +1,72 @@
+package eu.crg.qsample.charts.entity;
+
+import eu.crg.qsample.plot.Plot;
+import eu.crg.qsample.wetlab.WetLab;
+
+import javax.persistence.*;
+
+@Entity
+@Table(
+    name = "wetlab_plot_configs",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"wetlab_id", "plot_id"})
+)
+public class WetlabPlotConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wetlab_id", nullable = false)
+    private WetLab wetlab;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "plot_id", nullable = false)
+    private Plot plot;
+
+    @Column(name = "is_enabled", nullable = false)
+    private Boolean enabled = true;
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex = 0;
+
+    public Long getId() {
+        return id;
+    }
+
+    public WetLab getWetlab() {
+        return wetlab;
+    }
+
+    public Plot getPlot() {
+        return plot;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public Integer getOrderIndex() {
+        return orderIndex;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setWetlab(WetLab wetlab) {
+        this.wetlab = wetlab;
+    }
+
+    public void setPlot(Plot plot) {
+        this.plot = plot;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void setOrderIndex(Integer orderIndex) {
+        this.orderIndex = orderIndex;
+    }
+}

--- a/src/main/java/eu/crg/qsample/charts/repository/WetlabPlotConfigRepository.java
+++ b/src/main/java/eu/crg/qsample/charts/repository/WetlabPlotConfigRepository.java
@@ -1,0 +1,11 @@
+package eu.crg.qsample.charts.repository;
+
+import eu.crg.qsample.charts.entity.WetlabPlotConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WetlabPlotConfigRepository extends JpaRepository<WetlabPlotConfig, Long> {
+
+    List<WetlabPlotConfig> findByWetlabIdOrderByOrderIndexAsc(Long wetlabId);
+}

--- a/src/main/java/eu/crg/qsample/wetlab/WetLabService.java
+++ b/src/main/java/eu/crg/qsample/wetlab/WetLabService.java
@@ -4,14 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import eu.crg.qsample.data.DataRepository;
+import eu.crg.qsample.charts.entity.WetlabPlotConfig;
+import eu.crg.qsample.charts.repository.WetlabPlotConfigRepository;
 import eu.crg.qsample.exceptions.NotFoundException;
 import eu.crg.qsample.file.FileRepository;
-import eu.crg.qsample.file.QCloud2File;
+import eu.crg.qsample.plot.Plot;
 
 @Service
 public class WetLabService {
@@ -22,16 +24,19 @@ public class WetLabService {
     @Autowired
     FileRepository fileRepo;
 
+    @Autowired
+    WetlabPlotConfigRepository wetlabPlotConfigRepository;
+
     public List<WetLab> getAllWetLabs() {
         List<WetLab> wetLabs = new ArrayList<>();
-        wetLabRepo.findAll().forEach(wetLabs::add);
+        wetLabRepo.findAll().forEach(wetlab -> wetLabs.add(copyWithConfiguredPlots(wetlab)));
         return wetLabs;
     }
 
     public WetLab getByApiKey(UUID apiKey) {
         Optional<WetLab> wetlabOpt = wetLabRepo.findOneByApiKey(apiKey);
         if (wetlabOpt.isPresent()) {
-            return wetlabOpt.get();
+            return copyWithConfiguredPlots(wetlabOpt.get());
         } else {
             throw new NotFoundException("WetLab not found");
         }
@@ -39,6 +44,32 @@ public class WetLabService {
 
     public List<WetLabFile> getWetLabFilesByApiKey(UUID apiKey) {
         return fileRepo.findAllByTypeApiKey(apiKey);
+    }
+
+    private WetLab copyWithConfiguredPlots(WetLab wetlab) {
+        return new WetLab(
+                wetlab.getId(),
+                wetlab.getApiKey(),
+                wetlab.getName(),
+                getConfiguredPlots(wetlab),
+                wetlab.getWetlabCategory()
+        );
+    }
+
+    private List<Plot> getConfiguredPlots(WetLab wetlab) {
+        List<WetlabPlotConfig> configs =
+                wetlabPlotConfigRepository
+                        .findByWetlabIdOrderByOrderIndexAsc(wetlab.getId());
+
+        if (configs == null || configs.isEmpty()) {
+            return wetlab.getPlot();
+        }
+
+        return configs
+                .stream()
+                .filter(config -> Boolean.TRUE.equals(config.getEnabled()))
+                .map(WetlabPlotConfig::getPlot)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/resources/db/migration/V1_39__create_wetlab_plot_configs.sql
+++ b/src/main/resources/db/migration/V1_39__create_wetlab_plot_configs.sql
@@ -1,0 +1,28 @@
+CREATE TABLE wetlab_plot_configs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    wetlab_id BIGINT NOT NULL,
+    plot_id BIGINT NOT NULL,
+    is_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    order_index INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_wetlab_plot_configs_wetlab_plot (wetlab_id, plot_id),
+    KEY idx_wetlab_plot_configs_wetlab_id (wetlab_id),
+    KEY idx_wetlab_plot_configs_plot_id (plot_id),
+    CONSTRAINT fk_wetlab_plot_configs_wetlab
+        FOREIGN KEY (wetlab_id) REFERENCES wetlab(id),
+    CONSTRAINT fk_wetlab_plot_configs_plot
+        FOREIGN KEY (plot_id) REFERENCES plot(id)
+);
+
+INSERT INTO wetlab_plot_configs (
+    wetlab_id,
+    plot_id,
+    is_enabled,
+    order_index
+)
+SELECT
+    wet_lab_id AS wetlab_id,
+    plot_id,
+    TRUE AS is_enabled,
+    ROW_NUMBER() OVER (PARTITION BY wet_lab_id ORDER BY plot_id) AS order_index
+FROM wetlab_plot;


### PR DESCRIPTION
Adds configurable Sample preparation QC / WetLab plot settings.\n\nBackend changes:\n- new additive wetlab_plot_configs table\n- WetLab plot config endpoints\n- WetLab responses apply enabled/order config\n- qsample-client submodule points to the matching UI commit\n\nValidated in DEV:\n- backend compile passes\n- frontend build passes\n- WetLab settings UI works\n- WetLab chart display respects enabled/order settings\n\nQGenerator and injection conditions are not touched.